### PR TITLE
Add Visual Studio Code instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ https://github.com/rosshemsley/SublimeClangFormat/blob/master/README.md
 
 ### Usage with Visual Studio Code
 
-Install the [c/c++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+Install the [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
 
 Put the ``.clang-format`` file in your workspace.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Configuration Clang format in Sublime:
 
 https://github.com/rosshemsley/SublimeClangFormat/blob/master/README.md
 
+### Usage with Visual Studio Code
+
+Install the [c/c++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+Put the ``.clang-format`` file in your workspace.
+
+Select ``Format Document`` in the right-click context menu, or use the shortcut ``Ctrl+Shift+I``.
+
+This explanation and more [here](https://code.visualstudio.com/docs/languages/cpp#_code-formatting).
+
 ## Exceptions to clang-format
 
 Occationally the auto formatting used by clang-format might not make sense e.g. for lists of items that are easier to read on separate lines. It can be overwritten with the commands:


### PR DESCRIPTION
Add instructions to README.md to setup clang formatting in Visual Studio Code.