### PR TITLE
Removed duplicated formatting option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,6 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true
 AlwaysBreakBeforeMultilineStrings: false
 BreakBeforeBinaryOperators: false


### PR DESCRIPTION
Item `AllowShortLoopsOnASingleLine: false` appears twice in the format configuration.
This pull request removes the second occurrence.