### PR TITLE
Don't break multi-line strings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AlwaysBreakTemplateDeclarations: true
-AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakBeforeMultilineStrings: true
 BreakBeforeBinaryOperators: false
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: true


### PR DESCRIPTION
`AlwaysBreakBeforeMultilineStrings: false` will make the following
change, causing howls.  Setting it `true` didn't make any difference
on other parts of code (it won't try to recombine multi-line strings).

    -const std::unordered_map<uint, std::string> BLAH_BLAH_MAP(
    -    { { ITEM_UNO, "Lorem ipsum dolor sit amet, consectetur adipiscing" },
    -      { ITEM_DOS_SUPER_DUPER_YUCK,
    -        "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium "
    -        "doloremque" },
    - [...]
    +const std::unordered_map<uint, std::string> BLAH_BLAH_MAP({ { ITEM_UNO, "Lorem ipsum dolor sit amet, consectetur "
    +                                                                         "adipiscing" },
    +                                                             { ITEM_DOS_SUPER_DUPER_YUCK, "Sed ut perspiciatis "
    +                                                                                          "unde omnis iste natus "
    +                                                                                          "error sit voluptatem "
    +                                                                                          "accusantium" },
    + [...]