### PR TITLE
adapt to clang-format-10 for ros noetic

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,16 +50,14 @@ SpaceAfterCStyleCast: false
 BreakBeforeBraces: Custom
 
 # Control of individual brace wrapping cases
-BraceWrapping: {
-    AfterClass: 'true'
-    AfterControlStatement: 'true'
-    AfterEnum : 'true'
-    AfterFunction : 'true'
-    AfterNamespace : 'true'
-    AfterStruct : 'true'
-    AfterUnion : 'true'
-    BeforeCatch : 'true'
-    BeforeElse : 'true'
-    IndentBraces : 'false'
-}
-...
+BraceWrapping:
+  AfterClass: 'true'
+  AfterControlStatement: 'true'
+  AfterEnum : 'true'
+  AfterFunction : 'true'
+  AfterNamespace : 'true'
+  AfterStruct : 'true'
+  AfterUnion : 'true'
+  BeforeCatch : 'true'
+  BeforeElse : 'true'
+  IndentBraces : 'false'


### PR DESCRIPTION
In Ubuntu 20.04LTS (ROS noetic), the default clang-format is 10, which raised YAML error.

This patch should fix it, but maybe it's worth another branch or tag, since I didn't test it against clang-format-3.9.